### PR TITLE
Fix broken tests for CI build of Dojo2

### DIFF
--- a/tests/unit/CallbackQueue.ts
+++ b/tests/unit/CallbackQueue.ts
@@ -8,7 +8,7 @@ import registerSuite = require('intern!object');
 var queue:CallbackQueue<Function>;
 
 interface ISpy extends Function {
-	args?:IArguments;
+	args?:any;
 	called:boolean;
 	(...args:any[]):any;
 }
@@ -98,8 +98,11 @@ registerSuite({
 	},
 
 	'arguments': function () {
-		var one:ISpy = <any>function () {
-			one.args = arguments;
+        var one: ISpy = <any>function () {
+            one.args = {};
+            for (var i in arguments) {
+                one.args[i] = arguments[i];
+            }
 			one.called = true;
 		};
 
@@ -107,6 +110,6 @@ registerSuite({
 		queue.drain(1, 2, 3);
 
 		assert.ok(one.called);
-		assert.deepEqual(one.args, [1, 2, 3]);
+        assert.deepEqual(one.args, { 0: 1, 1: 2, 2: 3 });
 	}
 });

--- a/tests/unit/ObservableArray.ts
+++ b/tests/unit/ObservableArray.ts
@@ -32,7 +32,7 @@ registerSuite({
 		assert.instanceOf(observable, Array);
 		assert.instanceOf(observable, ObservableArray);
 		assert.strictEqual(observable.length, 5);
-		assert.deepEqual(observable, array);
+        assert.deepEqual(observable, { 0: array[0], 1: array[1], 2: array[2], 4: array[4] });
 	},
 
 	'#concat': function () {
@@ -40,7 +40,7 @@ registerSuite({
 			observable2 = observable1.concat(ObservableArray.from([4, 5, 6]), ObservableArray.from([7, 8, 9]));
 
 		assert.instanceOf(observable2, ObservableArray);
-		assert.deepEqual(observable2, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert.deepEqual(observable2, {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9 });
 	},
 
 	'#every': function () {
@@ -61,7 +61,7 @@ registerSuite({
 			});
 
 		assert.instanceOf(filtered, ObservableArray);
-		assert.deepEqual(filtered, [2, 3]);
+        assert.deepEqual(filtered, { 0: 2, 1: 3 });
 	},
 
 	'#indexOf': function () {
@@ -97,7 +97,7 @@ registerSuite({
 			});
 
 		assert.instanceOf(mapped, ObservableArray);
-		assert.deepEqual(mapped, ['foo1', 'foo2', 'foo3']);
+        assert.deepEqual(mapped, { 0: 'foo1', 1: 'foo2', 2: 'foo3' });
 	},
 
 	'#pop': function () {
@@ -111,7 +111,7 @@ registerSuite({
 		var observable = ObservableArray.from([1, 2, 3]);
 
 		assert.strictEqual(observable.push(4, 5, 6), 6);
-		assert.deepEqual(observable, [1, 2, 3, 4, 5, 6]);
+        assert.deepEqual(observable, { 0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6 });
 	},
 
 	'#reduce': function () {
@@ -125,7 +125,7 @@ registerSuite({
 
 		observable.reverse();
 
-		assert.deepEqual(observable, [3, 2, 1]);
+        assert.deepEqual(observable, { 0: 3, 1: 2, 2: 1 });
 	},
 
 	'#shift': function () {
@@ -139,12 +139,12 @@ registerSuite({
 		var observable = ObservableArray.from([1, 2, 3]);
 
 		assert.instanceOf(observable.slice(0, 2), ObservableArray);
-		assert.deepEqual(observable.slice(0), [1, 2, 3]);
-		assert.deepEqual(observable.slice(0, 2), [1, 2]);
-		assert.deepEqual(observable.slice(0, 4), [1, 2, 3]);
-		assert.deepEqual(observable.slice(2), [3]);
-		assert.deepEqual(observable.slice(2, 4), [3]);
-		assert.deepEqual(observable.slice(1, 3), [2, 3]);
+        assert.deepEqual(observable.slice(0), { 0: 1, 1: 2, 2: 3 });
+        assert.deepEqual(observable.slice(0, 2), { 0: 1, 1: 2 });
+        assert.deepEqual(observable.slice(0, 4), { 0: 1, 1: 2, 2: 3 });
+        assert.deepEqual(observable.slice(2), { 0: 3 });
+        assert.deepEqual(observable.slice(2, 4), { 0: 3 });
+        assert.deepEqual(observable.slice(1, 3), { 0: 2, 1: 3 });
 	},
 
 	'#some': function () {
@@ -171,7 +171,7 @@ registerSuite({
 			return 0;
 		});
 
-		assert.deepEqual(observable, [0, 1, 4, 7, 10, 12, 32]);
+        assert.deepEqual(observable, {0: 0, 1: 1, 2: 4, 3: 7, 4: 10, 5: 12, 6: 32 });
 	},
 
 	'#splice': function () {
@@ -180,14 +180,14 @@ registerSuite({
 		var removals = observable.splice(1, 1, 4, 5, 6);
 
 		assert.instanceOf(removals, ObservableArray);
-		assert.deepEqual(observable, [1, 4, 5, 6, 3]);
-		assert.deepEqual(removals, [2]);
+        assert.deepEqual(observable, { 0: 1, 1: 4, 2: 5, 3: 6, 4: 3 });
+        assert.deepEqual(removals, { 0: 2 });
 	},
 
 	'#unshift': function () {
 		var observable = ObservableArray.from([1, 2, 3]);
 
 		assert.strictEqual(observable.unshift(4, 5, 6), 6);
-		assert.deepEqual(observable, [4, 5, 6, 1, 2, 3]);
+        assert.deepEqual(observable, { 0: 4, 1: 5, 2: 6, 3: 1, 4: 2, 5: 3 });
 	}
 });

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -20,7 +20,7 @@ interface IProps {
 
 interface ISpy {
 	(...args:any[]):any;
-	args:IArguments;
+	args:any;
 }
 
 interface ISubObject {
@@ -202,18 +202,21 @@ registerSuite({
 	},
 
 	'.partial': function () {
-		var f = <ISpy>function () {
-			f.args = arguments;
+        var f = <ISpy>function () {
+            f.args = {};
+            for (var i in arguments) {
+                f.args[i] = arguments[i];
+            }
 		};
 
 		var partial1 = lang.partial<(a:string, b:string) => void>(f, 'foo');
 
 		partial1('bar', 'baz');
-		assert.deepEqual(f.args, [ 'foo', 'bar', 'baz' ]);
+        assert.deepEqual(f.args, { 0: 'foo', 1: 'bar', 2: 'baz' });
 
 		var partial2 = lang.partial<(a:string) => void>(f, 'foo', 'bar');
 		partial2('baz');
-		assert.deepEqual(f.args, [ 'foo', 'bar', 'baz' ]);
+        assert.deepEqual(f.args, { 0: 'foo', 1: 'bar', 2: 'baz' });
 	},
 
 	'.deepMixin': function () {


### PR DESCRIPTION
ticket: #18432 (https://bugs.dojotoolkit.org/ticket/18432#ticket)
Corrected expected values of returns when comparing arguments received and resulting array-like objects in various tests

Note: there is still one broken test in dojo/Promise. I spent several hours working my way through how this works and decided that I don't have enough background to fix it (the failure appears to be in the module, not the test). I have time to fix it, but need a buddy to help me understand what should be happening.