### PR TITLE
Update `isPromise` in Promise.ts

### DIFF
--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -3,7 +3,7 @@ import nextTick = require('./nextTick');
 type Callback = (...args: any[]) => void;
 
 function isPromise(value: any): boolean {
-	return value && typeof value.then === 'function';
+	return value ? typeof value.then === 'function' : false;
 }
 
 function runCallbacks(callbacks: Array<Callback>, ...args: any[]): void {


### PR DESCRIPTION
Currently the `isPromise` function will not return a `boolean` if the following examples:

``` ts
isPromise(); // undefined
isPromise(undefined); // undefined
isPromise(null); // null
isPromise(''); // empty string
isPromise(0); // 0
```

This currently isn't that big of an issue seeing as the `isPromise` function is currently only being used once on [Line 89](https://github.com/dojo/dojo2/blob/f79fd62f90514bd6877a4789ac9ea480e90507b5/src/Promise.ts#L89).
